### PR TITLE
Installing openssl as it is required by the TLS plugin

### DIFF
--- a/docker-images/haraka/Dockerfile
+++ b/docker-images/haraka/Dockerfile
@@ -16,7 +16,7 @@ FROM node:lts-alpine as app
 
 ENV NODE_ENV production
 
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini openssl
 
 WORKDIR /app
 COPY --from=builder /app /app


### PR DESCRIPTION
OpenSSL is required by the Haraka TLS plugin. If it is not installed and you deposit a certificate you will get the error `spawn openssl ENOENT`.